### PR TITLE
Small textual changes to clarify role of Foundation For Public Code

### DIFF
--- a/src/pages/common-ground.md
+++ b/src/pages/common-ground.md
@@ -21,6 +21,6 @@ De code van Signalen is openbaar en kun je niet zozeer spreken over eigenaarscha
 
 ### Samen werken aan Signalen
 
-In samenwerking met VNG Realisatie, gemeente Amsterdam, ’s-Hertogenbosch, Almere en gefaciliteerd door de Foundation for Public Code is Signalen toegankelijk gemaakt voor iedere gemeente in Nederland.
+In samenwerking met VNG Realisatie, gemeente Amsterdam, ’s-Hertogenbosch, Almere en gefaciliteerd door de Foundation for Public Code, is Signalen toegankelijk gemaakt voor iedere gemeente in Nederland.
 
 Conform de principes van opensource kan iedereen suggesties aandragen voor aanpassing of verbetering van de software. Samen Signalen gebruiken en samen Signalen verbeteren. Op die manier werken we met vereende krachten aan het verbeteren van klanttevredenheid en de leefbaarheid in onze gemeenten.

--- a/src/pages/common-ground.md
+++ b/src/pages/common-ground.md
@@ -21,6 +21,6 @@ De code van Signalen is openbaar en kun je niet zozeer spreken over eigenaarscha
 
 ### Samen werken aan Signalen
 
-In samenwerking met VNG Realisatie, gemeente Amsterdam, ’s-Hertogenbosch, Almere en The Foundation for Public Code is Signalen toegankelijk gemaakt voor iedere gemeente in Nederland.
+In samenwerking met VNG Realisatie, gemeente Amsterdam, ’s-Hertogenbosch, Almere en gefaciliteerd door de Foundation for Public Code is Signalen toegankelijk gemaakt voor iedere gemeente in Nederland.
 
 Conform de principes van opensource kan iedereen suggesties aandragen voor aanpassing of verbetering van de software. Samen Signalen gebruiken en samen Signalen verbeteren. Op die manier werken we met vereende krachten aan het verbeteren van klanttevredenheid en de leefbaarheid in onze gemeenten.

--- a/src/pages/over-signalen.md
+++ b/src/pages/over-signalen.md
@@ -5,7 +5,7 @@ template: "default"
 
 ## Samenwerken aan Signalen
 
-In 2020 startte heeft VNG Realisatie in samenwerking met Amsterdam het Signalen Initiatief gestart. Met dit initiatief willen we Signalen om deze slimme oplossing beschikbaar maken te maken voor andere gemeenten en overheden in Nederland. Dit doen zij we samen met de Gemeente ’s-Hertogenbosch, Gemeente Almere en The Foundation for Public Code. Samen maken wij Signalen toepasbaar toegankelijk voor iedere gemeente in Nederland.
+In 2020 startte heeft VNG Realisatie in samenwerking met Amsterdam het Signalen Initiatief gestart. Met dit initiatief willen we Signalen om deze slimme oplossing beschikbaar maken te maken voor andere gemeenten en overheden in Nederland. Dit doen we samen met de Gemeente ’s-Hertogenbosch en Gemeente Almere. We worden daarbij gefaciliteerd door The Foundation for Public Code. Samen maken wij Signalen toepasbaar toegankelijk voor iedere gemeente in Nederland.
 
 Wil je ook Signalen gebruiken?
 
@@ -23,4 +23,3 @@ De wens tot een hogere klanttevredenheid heeft geleid tot de ontwikkeling van Si
 Sinds de invoering is de klanttevredenheid over de afhandeling van meldingen in Amsterdam met 30 procent gestegen.
 
 Video over Signalen in Amsterdam: https://www.youtube.com/watch?v=I2Z-mRFt3pg
-

--- a/src/pages/roadmap.js
+++ b/src/pages/roadmap.js
@@ -56,7 +56,7 @@ const RoadmapPage = () => (
           <Timeline.Content>
             <Span fontSize="0.9rem">2 maart 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Kopgroep Signalen</Heading>
-            <p>‘s-Hertogenbosch, Amsterdam, Almere, VNG Realisatie vormen samen de Kopgroep gefaciliteerd door de Foundation for Public Code met als doel om Signalen bruikbaar te maken voor andere gemeenten.</p>
+            <p>‘s-Hertogenbosch, Amsterdam, Almere, VNG Realisatie vormen samen de Kopgroep, gefaciliteerd door de Foundation for Public Code met als doel om Signalen bruikbaar te maken voor andere gemeenten.</p>
             <ResponsiveImage src={connectingTeams} />
           </Timeline.Content>
         </Timeline.Container>

--- a/src/pages/roadmap.js
+++ b/src/pages/roadmap.js
@@ -56,7 +56,7 @@ const RoadmapPage = () => (
           <Timeline.Content>
             <Span fontSize="0.9rem">2 maart 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Kopgroep Signalen</Heading>
-            <p>‘s-Hertogenbosch, Amsterdam, Almere, VNG Realisatie en de Foundation for Public Code vormen samen de Kopgroep met als doel om Signalen bruikbaar te maken voor andere gemeenten.</p>
+            <p>‘s-Hertogenbosch, Amsterdam, Almere, VNG Realisatie vormen samen de Kopgroep gefaciliteerd door de Foundation for Public Code met als doel om Signalen bruikbaar te maken voor andere gemeenten.</p>
             <ResponsiveImage src={connectingTeams} />
           </Timeline.Content>
         </Timeline.Container>


### PR DESCRIPTION
Small textual changes to clarify the role of the Foundation For Public Code as a facilitator rather than a development partner.

@bvhme could you review the proposed changes?
 