### PR TITLE
Harmonize use of term open source

### DIFF
--- a/src/components/Payoff/index.en.js
+++ b/src/components/Payoff/index.en.js
@@ -9,7 +9,7 @@ const Payoff = () => (
       <StyledTextContainer>
         <StyledHeading>Signalen</StyledHeading>
         <StyledParagraph>Working together for quality of life</StyledParagraph>
-        <StyledSubParagraph>Signalen is an open-source process and task system for governments, which automatically categorizes and routes reports about public space for processing by the appropriate handler.</StyledSubParagraph>
+        <StyledSubParagraph>Signalen is an open source process and task system for governments, which automatically categorizes and routes reports about public space for processing by the appropriate handler.</StyledSubParagraph>
         <StyledSubParagraph><a href="/en/#about-signalen">More information on Signalen</a></StyledSubParagraph>
       </StyledTextContainer>
     </StyledIntro>

--- a/src/components/Payoff/index.js
+++ b/src/components/Payoff/index.js
@@ -9,7 +9,7 @@ const Payoff = () => (
       <StyledTextContainer>
         <StyledHeading>Signalen</StyledHeading>
         <StyledParagraph>Samenwerken aan leefbaarheid</StyledParagraph>
-        <StyledSubParagraph>Signalen is een opensource proces- en taaksysteem voor overheden, dat meldingen over de openbare ruimte automatisch categoriseert en routeert voor afhandeling door de juiste behandelaar.</StyledSubParagraph>
+        <StyledSubParagraph>Signalen is een open source proces- en taaksysteem voor overheden, dat meldingen over de openbare ruimte automatisch categoriseert en routeert voor afhandeling door de juiste behandelaar.</StyledSubParagraph>
         <StyledSubParagraph><a href="/#over-signalen">Lees hier meer over Signalen</a></StyledSubParagraph>
       </StyledTextContainer>
     </StyledIntro>

--- a/src/pages/common-ground.md
+++ b/src/pages/common-ground.md
@@ -22,4 +22,4 @@ De code van Signalen is openbaar en kun je niet zozeer spreken over eigenaarscha
 
 In samenwerking met VNG Realisatie, gemeente Amsterdam, ’s-Hertogenbosch, Almere en gefaciliteerd door de Foundation for Public Code, is Signalen toegankelijk gemaakt voor iedere gemeente in Nederland.
 
-Conform de principes van opensource kan iedereen suggesties aandragen voor aanpassing of verbetering van de software. Samen Signalen gebruiken en samen Signalen verbeteren. Op die manier werken we met vereende krachten aan het verbeteren van klanttevredenheid en de leefbaarheid in onze gemeenten.
+Conform de principes van open source kan iedereen suggesties aandragen voor aanpassing of verbetering van de software. Samen Signalen gebruiken en samen Signalen verbeteren. Op die manier werken we met vereende krachten aan het verbeteren van klanttevredenheid en de leefbaarheid in onze gemeenten.

--- a/src/pages/index.en.js
+++ b/src/pages/index.en.js
@@ -41,7 +41,7 @@ const IndexPage = ({ location }) => (
       <Section id="about-signalen">
         <Flex>
           <Box>
-          <p> Signalen is an open-source process and task system for governments, which automatically categorizes and routes reports about public space for processing by the appropriate handler. </p>
+          <p> Signalen is an open source process and task system for governments, which automatically categorizes and routes reports about public space for processing by the appropriate handler. </p>
           </Box>
         </Flex>
       </Section>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -43,7 +43,7 @@ const IndexPage = ({ location }) => (
           <Box>
             <p>Signalen is een proces- en taaksysteem, ontwikkeld op initiatief van de gemeente Amsterdam voor het effectiever en klantvriendelijker afhandelen van meldingen over de openbare ruimte.</p>
             <p>Amsterdam krijgt per jaar zo’n 300.000 meldingen over de openbare ruimte te verwerken. Van huisraad bij de vuilnisbak tot en met verlaten sloepjes in de gracht. Ruim 1.400 ambtenaren werken 24/7 met het afhandelen van meldingen in Signalen. Sinds de invoering van Signalen is de klanttevredenheid over de afhandeling van meldingen in Amsterdam met ruim 30 procent gestegen.</p>
-            <p>De Signalen software is Open Source ontwikkeld en kan vrij gebruikt worden door andere overheden en gemeenten.</p>
+            <p>De Signalen software is open source ontwikkeld en kan vrij gebruikt worden door andere overheden en gemeenten.</p>
           </Box>
         </Flex>
       </Section>


### PR DESCRIPTION
'Open Source' 'opensource' and 'open-source' changed to 'open source'.

Works towards #45.