### PR TITLE
New locations for submitting feature requests

### DIFF
--- a/src/pages/using-signalen.en.md
+++ b/src/pages/using-signalen.en.md
@@ -22,7 +22,7 @@ Then you can contribute in the following ways:
 
 - Subscribe to the [Signalen community mailinglist](https://lists.publiccode.net/mailman/postorius/lists/signalen-discuss.lists.publiccode.net/)
 - Check outstanding feature requests on the [feature request backlog](https://github.com/orgs/Signalen/projects/2).
-- Make a new [feature request](https://github.com/orgs/Signalen/projects/2#card-48083806) using the [feature request template](https://github.com/orgs/Signalen/projects/2#card-48083806) if your requirement or wish is not listed. Note: Please fill it in completely otherwise your feature request cannot be processed.
+- Make a new [feature request](https://github.com/Signalen/product-steering/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=%5BFEATURE-REQUEST%5D) using the [feature request template](https://github.com/Signalen/product-steering/tree/main/.github/ISSUE_TEMPLATE) if your requirement or wish is not listed. Note: Please fill it in completely otherwise your feature request cannot be processed.
 - Announce your feature request on the [Signalen community mailinglist](https://lists.publiccode.net/mailman/postorius/lists/signalen-discuss.lists.publiccode.net/)
 
 Every two weeks, the Signalen product steering group meets to discuss all new feature requests and decide which features will be further developed. If your feature request is being processed, you are welcome to further explain your feature request in the consultation.

--- a/src/pages/using-signalen.md
+++ b/src/pages/using-signalen.md
@@ -22,7 +22,7 @@ Dan kun je op de volgende manieren bijdragen:
 
 - Abonneer je op de [Signalen community mailinglist](https://lists.publiccode.net/mailman/postorius/lists/signalen-discuss.lists.publiccode.net/)
 - Kijk naar de uitstaande [feature request backlog](https://github.com/orgs/Signalen/projects/2).
-- Maak een nieuw [feature request](https://github.com/orgs/Signalen/projects/2#card-48083806) aan conform het [feature request template](https://github.com/orgs/Signalen/projects/2#card-48083806) wanneer jouw eis of wens er niet tussen staat. NB: Vul het  volledig in anders kan je feature request niet in behandeling genomen worden.
+- Maak een nieuw [feature request](https://github.com/Signalen/product-steering/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=%5BFEATURE-REQUEST%5D) aan conform het [feature request template](https://github.com/Signalen/product-steering/tree/main/.github/ISSUE_TEMPLATE) wanneer jouw eis of wens er niet tussen staat. NB: Vul het  volledig in anders kan je feature request niet in behandeling genomen worden.
 - Kondig je feature request aan op de [Signalen community mailinglist](https://lists.publiccode.net/mailman/postorius/lists/signalen-discuss.lists.publiccode.net/)
 
 Iedere twee weken komt de Signalen product steering groep bij elkaar om alle nieuwe feature requests met elkaar te bespreken en te beslissen welke features verder ontwikkeld worden. Als je feature request in behandeling wordt genomen ben je van harte welkom om in het overleg jouw feature request nader toe te lichten.


### PR DESCRIPTION
Locations to submit feature requests have changed. In stead of making cards on our product steering board we now create issues on the product steering repository using the feature request template.  See https://github.com/Signalen/product-steering for more information.

The links to this locations have now been change to the using-signalen page in both Dutch and English
