### PR TITLE
Added code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Signalen Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a positive experience for everyone, regardless of who you are or on whose behalf you are making contributions. 
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+
+## Our Responsibilities
+
+Signalen maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Repository members, admins and owners have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an officialproject e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting one of the repository admins or owners directly. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The repository admins or owners is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Signalen maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the product team's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ We – the maintainers of this project – value your input, enjoy feedback and 
 
 We love issues and pull requests from everyone.
 
+When you are contributing, we expect you to follow our [code of conduct](CODE_OF_CONDUCT.md).
+
 ## Problems, suggestions and questions
 
 You don't need to change any of our code or documentation to be a contributor. Many contributors add to our software by reporting problems, suggesting changes and asking simple and difficult questions. To do this, you can create a [GitHub Issue](https://help.github.com/articles/creating-an-issue/) for this project.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ In the current configuration only the Payoff component and the road map page and
 More information about the configuration and implementation can be found here:
 https://www.gatsbyjs.com/blog/2020-02-19-how-to-build-multilingual-sites-with-gatsby/
 
+## Code of Conduct
+
+We have a [code of conduct](CODE_OF_CONDUCT.md) that we expect you to follow.
 
 ## License
 

--- a/src/pages/contact.en.md
+++ b/src/pages/contact.en.md
@@ -49,3 +49,7 @@ Every month contributing developer members of our community conduct a technical 
 ### Monthly Product Steering call
 
 Every month contributing members of our community conduct a product steering meeting to discuss new features or user issues.  You are welcome to join this meeting by sending a request to signalen-discuss@lists.publiccode.net. Make sure you first [join the Signalen mailinglist](https://lists.publiccode.net/mailman/postorius/lists/signalen-discuss.lists.publiccode.net/) prior to sending a message.
+
+### Code of Conduct
+
+We have a [code of conduct](../CODE_OF_CONDUCT.md) that we expect you to follow.

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -50,3 +50,6 @@ Elke maand houden ontwikkelaars van onze community een technische stuurbijeenkom
 ### Maandelijkse Product Steering call
 
 Elke maand houden product owners van onze community een productstuurvergadering om nieuwe functies of gebruikersproblemen te bespreken. U bent van harte welkom om deze bijeenkomst bij te wonen door een verzoek te sturen naar signalen-discuss@lists.publiccode.net. Zorg ervoor dat je eerst [lid wordt van de Signalen mailinglist] (https://lists.publiccode.net/mailman/postorius/lists/signalen-discuss.lists.publiccode.net/) voordat je een bericht verstuurt.
+
+### Gedragscode
+We hebben een [gedragscode](../CODE_OF_CONDUCT.md) waarvan we verwachten dat u deze volgt.


### PR DESCRIPTION
Adapted the version from OpenZaak, but since we don't have a formal technical steering team i referred to members of the
repositories instead.

Fixes #28