### PR TITLE
Fix link

### DIFF
--- a/src/pages/news/2021-05-21-OS2-community-blog-post.md
+++ b/src/pages/news/2021-05-21-OS2-community-blog-post.md
@@ -1,0 +1,12 @@
+---
+path: "/news/2021-05-21-OS2-community-blog-post/"
+date: "2021-05-21"
+title: "Blogpost op OS2 bevatte Signalen"
+lang: nl
+template: default
+---
+
+# Blogpost op OS2 bevatte Signalen
+Onlangs is een blogpost over [samenwerking in de praktijk](https://os2.eu/blog/blog-samarbete-i-praktiken) gepubliceerd door Jan Ainali van Foundation for Public Code op de OS2-blog.
+OS2 is een Deens netwerk over het specificeren, ontwikkelen en beheren van digitale oplossingen gemaakt door openbare instanties en voor publieke instellingen - in samenwerking met particuliere leveranciers, zonder vendor-lock in.
+De blogpost behandelt enkele essentiële zaken voor een goede samenwerking en gebruikt voorbeelden uit de Signalen-gemeenschap om te illustreren hoe dit in de praktijk kan worden gedaan.

--- a/src/pages/news/2021-05-21-interview-first-replicator.en.md
+++ b/src/pages/news/2021-05-21-interview-first-replicator.en.md
@@ -1,0 +1,17 @@
+---
+path: "/en/news/2021-05-21-interview-first-replicator/"
+date: "2021-05-21"
+title: "Interview: Early impressions of 's-Hertogenbosch as first replicator of Signalen"
+lang: en
+template: default
+---
+
+# Interview: Early impressions of 's-Hertogenbosch as first replicator of Signalen
+
+[Amy van Someren](https://github.com/someren), Functional Manager at the Dutch municipality of 's-Hertogenbosch has recently been invited to the podcast ['Let's talk about Public Code'](https://podcast.publiccode.net/) from the [Foundation for Public Code](https://publiccode.net). The civil servant, shared her experiences and challenges while working with Signalen and in the open on a daily basis.
+
+The podcast is now available in the following formats:
+- Watch it on [Youtube](https://www.youtube.com/watch?v=zPF_3DpNA0A)
+- [Periscope](https://www.pscp.tv/w/1RDGlPvwqYlGL)
+- [Facebook](https://www.facebook.com/285004318294/videos/210340460598152)
+- Or you can listen to it in audio [podcast format](https://podcast.publiccode.net/e/5-amy-van-someren-signalen/).

--- a/src/pages/news/2021-05-21-interview-first-replicator.md
+++ b/src/pages/news/2021-05-21-interview-first-replicator.md
@@ -1,0 +1,17 @@
+---
+path: "/news/2021-05-21-interview-first-replicator/"
+date: "2021-05-21"
+title: "Interview: Eerste indrukken van 's-Hertogenbosch als eerste replicator van Signalen"
+lang: nl
+template: default
+---
+
+# Interview: Eerste indrukken van 's-Hertogenbosch als eerste replicator van Signalen
+
+[Amy van Someren](https://github.com/someren), Functioneel Beheerder bij de Gemeente 's-Hertogenbosch is onlangs uitgenodigd voor de podcast [' Let's talk about Public Code '](https://podcast.publiccode.net/) van de [Foundation for Public Code](https://publiccode.net). De ambtenaar deelde dagelijks haar ervaringen en uitdagingen tijdens het werken met Signalen en in de open lucht.
+
+De podcast is nu beschikbaar in de volgende formaten:
+- Bekijk het op [Youtube](https://www.youtube.com/watch?v=zPF_3DpNA0A)
+- [Periscope](https://www.pscp.tv/w/1RDGlPvwqYlGL)
+- [Facebook](https://www.facebook.com/285004318294/videos/210340460598152)
+- Of je kunt ernaar luisteren in [podcast formaat (alleen audio)](https://podcast.publiccode.net/e/5-amy-van-someren-signalen/).


### PR DESCRIPTION
A number of blogpost where inaccessible due to:

- using special characters in filenames
-  not referring to an existing filename in the path: section of a blogpost


When contributing please check if you contributions work locally before creating a PR and merging to master.

