### PR TITLE
Roadmap 2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache/
 node_modules/
 public/
+package-lock.json

--- a/src/pages/index.en.js
+++ b/src/pages/index.en.js
@@ -111,7 +111,7 @@ const IndexPage = ({ location }) => (
       <Timeline>
         <Timeline.Container align="left">
           <Timeline.Content>
-            <Span fontSize="0.9rem">May 2021</Span>
+            <Span fontSize="0.9rem">March 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen is used in production at the municipality of 's-Hertogenbosch</Heading>
             <p>Signalen was taken into production at the beginning of March in the municipality of 's-Hertogenbosch.</p>
           </Timeline.Content>

--- a/src/pages/index.en.js
+++ b/src/pages/index.en.js
@@ -111,9 +111,9 @@ const IndexPage = ({ location }) => (
       <Timeline>
         <Timeline.Container align="left">
           <Timeline.Content>
-            <Span fontSize="0.9rem">Q4 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Ready for production</Heading>
-            <p>Delivery of a municipal neutral version of the Signalen software. Signalen is ready for production for the municipal participants from the Kopgroep.</p>
+            <Span fontSize="0.9rem">May 2021</Span>
+            <Heading as="h3" fontSize="1.5rem">Signalen is used in production at the municipality of 's-Hertogenbosch</Heading>
+            <p>Signalen was taken into production at the beginning of May in the municipality of 's-Hertogenbosch.</p>
           </Timeline.Content>
         </Timeline.Container>
       </Timeline>

--- a/src/pages/index.en.js
+++ b/src/pages/index.en.js
@@ -113,7 +113,7 @@ const IndexPage = ({ location }) => (
           <Timeline.Content>
             <Span fontSize="0.9rem">May 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen is used in production at the municipality of 's-Hertogenbosch</Heading>
-            <p>Signalen was taken into production at the beginning of May in the municipality of 's-Hertogenbosch.</p>
+            <p>Signalen was taken into production at the beginning of March in the municipality of 's-Hertogenbosch.</p>
           </Timeline.Content>
         </Timeline.Container>
       </Timeline>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -113,9 +113,9 @@ const IndexPage = ({ location }) => (
       <Timeline>
         <Timeline.Container align="left">
           <Timeline.Content>
-            <Span fontSize="0.9rem">Q4 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Klaar voor productie</Heading>
-            <p>Oplevering gemeente-neutrale versie Signalen-software. Signalen is klaar voor productie bij de gemeentelijke deelnemers uit de Kopgroep.</p>
+            <Span fontSize="0.9rem">Mei 2021</Span>
+            <Heading as="h3" fontSize="1.5rem">Signalen is in gebruik bij 's-Hertogenbosch</Heading>
+            <p>Signalen is begin mei in product genomen in de gemeente 's-Hertogenbosch.</p>
           </Timeline.Content>
         </Timeline.Container>
       </Timeline>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -113,7 +113,7 @@ const IndexPage = ({ location }) => (
       <Timeline>
         <Timeline.Container align="left">
           <Timeline.Content>
-            <Span fontSize="0.9rem">Mei 2021</Span>
+            <Span fontSize="0.9rem">Maart 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen is in gebruik bij 's-Hertogenbosch</Heading>
             <p>Signalen is begin mei in product genomen in de gemeente 's-Hertogenbosch.</p>
           </Timeline.Content>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -115,7 +115,7 @@ const IndexPage = ({ location }) => (
           <Timeline.Content>
             <Span fontSize="0.9rem">Maart 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen is in gebruik bij 's-Hertogenbosch</Heading>
-            <p>Signalen is begin mei in product genomen in de gemeente 's-Hertogenbosch.</p>
+            <p>Signalen is begin maart in product genomen in de gemeente 's-Hertogenbosch.</p>
           </Timeline.Content>
         </Timeline.Container>
       </Timeline>

--- a/src/pages/news/2021-06-24-roadmap.en.md
+++ b/src/pages/news/2021-06-24-roadmap.en.md
@@ -25,7 +25,7 @@ The second half year we have decided to focus our efforts on making Signalen mor
 | 4 | Notify practitioners| Send mail / Make configurable | medium |
 
 ---
-<br/>
-More detailed information can be found on our [project board on Github](https://github.com/orgs/Signalen/projects/) with user stories labeled as “Roadmap 2021”.
+
+More detailed information can be found on our [project board on Github](https://github.com/orgs/Signalen/projects/2) with user stories labeled as “Roadmap 2021”.
 
 At the moment the product steering group is busy looking together with other community members how this functionality can be funded and implemented.

--- a/src/pages/news/2021-06-24-roadmap.en.md
+++ b/src/pages/news/2021-06-24-roadmap.en.md
@@ -1,0 +1,32 @@
+---
+path: "/en/news/2021-06-24-roadmap/"
+date: "2021-06-24"
+title: "Roadmap Signalen July 2021 - December 2021"
+lang: en
+template: default
+---
+
+## Roadmap Signalen July 2021 - December 2021
+The product steering group has been busy working with all community members of Signalen to
+determine which functional improvements they would like to see within Signalen.
+
+The second half year we have decided to focus our efforts on making Signalen more user-friendly for the people who handle the notifications. Below is a summary of the features we will be working on:
+
+---
+
+| Priority | Feature theme (epic) | Description | Complexity/ Scope of work |
+| -------- | -------- | -------- | -------- |
+| 1 | Granularity of read and write permissions | Adjust dropdown to read-only users -> small (depends on 1) | medium / large |
+| 2a | Filtering | Refactor | large |
+| 2b | Filtering | Autocomplete add address | small |
+| 3a | More user-friendly management | Routing rules in Django admin | small |
+| 3b | More user-friendly management | Machine learning, research needed | large |
+| 3c | More user-friendly management | Additional questions implementer in front-end| large |
+| 4 | Enrich data dump | Enrich data dump| small/medium |
+| 4 | Notify practitioners| Send mail / Make configurable | medium |
+
+---
+<br/>
+More detailed information can be found on our [project board on Github](https://github.com/orgs/Signalen/projects/) with user stories labeled as “Roadmap 2021”.
+
+At the moment the product steering group is busy looking together with other community members how this functionality can be funded and implemented.

--- a/src/pages/news/2021-06-24-roadmap.en.md
+++ b/src/pages/news/2021-06-24-roadmap.en.md
@@ -7,8 +7,7 @@ template: default
 ---
 
 ## Roadmap Signalen July 2021 - December 2021
-The product steering group has been busy working with all community members of Signalen to
-determine which functional improvements they would like to see within Signalen.
+The product steering group has been busy working with all community members of Signalen to determine which functional improvements they would like to see within Signalen.
 
 The second half year we have decided to focus our efforts on making Signalen more user-friendly for the people who handle the notifications. Below is a summary of the features we will be working on:
 

--- a/src/pages/news/2021-06-24-roadmap.md
+++ b/src/pages/news/2021-06-24-roadmap.md
@@ -1,0 +1,33 @@
+---
+path: "/news/2021-06-24-roadmap/"
+date: "2021-06-24"
+title: "Roadmap Signalen Juli 2021 - December 2021"
+lang: nl
+template: default
+---
+
+## Roadmap Signalen Juli 2021 - December 2021"
+De afgelopen tijd is de product steering groep druk bezig geweest om met alle community leden van Signalen
+vast te stellen welke verbeteringen en doorontwikkelingen zij graag zouden zien ten aanzien van Signalen.
+
+Het thema is dan ook om ons in de 2e helft van dit jaar te gaan richten op het gebruikersvriedenlijker maken
+van Signalen voor de mensen die de meldingen afhandelen. Hieronder volgt op hoofdlijnen aan welke onderdelen we zullen gaan werken:
+
+---
+
+| Prioriteit | Functie thema (epic) | Beschrijving | Complexiteit/ Omvang van werk |
+| -------- | -------- | -------- | -------- |
+| 1     | Granulariteit van lees- en schrijfrechten | Dropdown aanpassen naar gebruikers die alleen kunnen lezen -> small (afhankelijk van 1) | medium / large    |
+| 2a     | Filtering |  Refactor |  large    |
+| 2b     | Filtering |  Autocomplete toevoegen adres |  small    |
+| 3a     | Gebruikersvriendelijker beheer | Routeringsregels in Django admin |  small    |
+| 3b     | Gebruikersvriendelijker beheer | Machine learning, onderzoek nodig |  large   |
+| 3c     | Gebruikersvriendelijker beheer | Aanvullende vragen implementer in front-end|  large   |
+| 4     | Verrijken data dump | Verrijken data dump|  small/medium  |
+| 4     | Notificeren van behandelaars| Mailtje versturen / Instelbaar maken |  medium  |
+
+---
+<br/>
+Een gedetaillieerd overzicht kun je vinden op ons [project board op Github](https://github.com/orgs/Signalen/projects/) met user stories die gelabeled zijn als "Roadmap 2021”.
+
+Op het moment is de product steering groep druk bezig om te kijken samen met andere community leden hoe deze functionaliteit geimplementeerd kan gaan worden.

--- a/src/pages/news/2021-06-24-roadmap.md
+++ b/src/pages/news/2021-06-24-roadmap.md
@@ -26,7 +26,7 @@ van Signalen voor de mensen die de meldingen afhandelen. Hieronder volgt op hoof
 | 4     | Notificeren van behandelaars| Mailtje versturen / Instelbaar maken |  medium  |
 
 ---
-<br/>
-Meer detail informatie kun je vinden op ons [project board op Github](https://github.com/orgs/Signalen/projects/) met user stories die gelabeled zijn als "Roadmap 2021”.
+
+Meer detail informatie kun je vinden op ons [project board op Github](https://github.com/orgs/Signalen/projects/2) met user stories die gelabeled zijn als "Roadmap 2021”.
 
 Op het moment is de product steering groep druk bezig om te kijken samen met andere community leden hoe deze functionaliteit geimplementeerd kan gaan worden.

--- a/src/pages/news/2021-06-24-roadmap.md
+++ b/src/pages/news/2021-06-24-roadmap.md
@@ -7,8 +7,7 @@ template: default
 ---
 
 ## Roadmap Signalen Juli 2021 - December 2021
-De afgelopen tijd is de product steering groep druk bezig geweest om met alle community leden van Signalen
-vast te stellen welke verbeteringen en doorontwikkelingen zij graag zouden zien ten aanzien van Signalen.
+De afgelopen tijd is de product steering groep druk bezig geweest om met alle community leden van Signalen vast te stellen welke verbeteringen en doorontwikkelingen zij graag zouden zien ten aanzien van Signalen.
 
 Het thema is dan ook om ons in de 2e helft van dit jaar te gaan richten op het gebruikersvriedenlijker maken
 van Signalen voor de mensen die de meldingen afhandelen. Hieronder volgt op hoofdlijnen aan welke onderdelen we zullen gaan werken:

--- a/src/pages/news/2021-06-24-roadmap.md
+++ b/src/pages/news/2021-06-24-roadmap.md
@@ -6,7 +6,7 @@ lang: nl
 template: default
 ---
 
-## Roadmap Signalen Juli 2021 - December 2021"
+## Roadmap Signalen Juli 2021 - December 2021
 De afgelopen tijd is de product steering groep druk bezig geweest om met alle community leden van Signalen
 vast te stellen welke verbeteringen en doorontwikkelingen zij graag zouden zien ten aanzien van Signalen.
 
@@ -28,6 +28,6 @@ van Signalen voor de mensen die de meldingen afhandelen. Hieronder volgt op hoof
 
 ---
 <br/>
-Een gedetaillieerd overzicht kun je vinden op ons [project board op Github](https://github.com/orgs/Signalen/projects/) met user stories die gelabeled zijn als "Roadmap 2021”.
+Meer detail informatie kun je vinden op ons [project board op Github](https://github.com/orgs/Signalen/projects/) met user stories die gelabeled zijn als "Roadmap 2021”.
 
 Op het moment is de product steering groep druk bezig om te kijken samen met andere community leden hoe deze functionaliteit geimplementeerd kan gaan worden.

--- a/src/pages/roadmap.en.js
+++ b/src/pages/roadmap.en.js
@@ -42,30 +42,58 @@ const RoadmapPage = ({ location }) => (
     </Container>
     <Container>
       <Timeline>
-      <Timeline.Container align="right">
-          <Timeline.Content>
-            <Span fontSize="0.9rem">2018</Span>
-            <Heading as="h3" fontSize="1.5rem">Start of development of SIA</Heading>
-            <p>The Municipality of Amsterdam starts the development of Signalen in Amsterdam (SIA) with the Department of Services and the Datalab. SIA is open source and therefore freely usable for others.</p>
-            <ResponsiveImage src={startOntwikkeling} />
-          </Timeline.Content>
-        </Timeline.Container>
+
         <Timeline.Container align="left">
           <Timeline.Content>
-            <Span fontSize="0.9rem">2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Start initiative</Heading>
-            <p>Start of the Signalen initiative! Many municipalities in the Netherlands are interested in Signalen. Based on this enthusiasm, VNGr starts scaling up Signalen.</p>
-            <ResponsiveImage src={startInitiatief} />
+            <Span fontSize="0.9rem">May 2021</Span>
+            <Heading as="h3" fontSize="1.5rem">Signalen is used in production at the municipality of 's-Hertogenbosch</Heading>
+            <p>Signalen was taken into production at the beginning of May in the municipality of 's-Hertogenbosch.</p>
           </Timeline.Content>
         </Timeline.Container>
+
         <Timeline.Container align="right">
           <Timeline.Content>
-            <Span fontSize="0.9rem">March 2nd, 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Signalen core group</Heading>
-            <p>'s-Hertogenbosch, Amsterdam, Almere, VNG Realization and the Foundation for Public Code together form the Kopgroep with the aim of making Signalen usable for other municipalities.</p>
-            <ResponsiveImage src={connectingTeams} />
+            <Span fontSize="0.9rem">2021</Span>
+            <Heading as="h3" fontSize="1.5rem">Scaling up</Heading>
+            <p>Scaling up Signalen at Dutch municipalities.</p>
+            <ResponsiveImage src={doorontwikkeling} />
           </Timeline.Content>
         </Timeline.Container>
+
+        <Timeline.Container align="left">
+          <Timeline.Content>
+            <Span fontSize="0.9rem">Q4 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Ready for production</Heading>
+            <p>Delivery of a municipal neutral version of the Signalen software. Signalen is ready for production for the municipal participants from the core group.</p>
+          </Timeline.Content>
+        </Timeline.Container>
+
+        <Timeline.Container align="right">
+          <Timeline.Content>
+            <Span fontSize="0.9rem">Sept 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Integral roadmap</Heading>
+            <p>The start towards one integral functional roadmap. The roadmap shows where Signalen is going and contains features that are valuable for every municipality.</p>
+          </Timeline.Content>
+        </Timeline.Container>
+
+        <Timeline.Container align="left">
+          <Timeline.Content>
+            <Span fontSize="0.9rem">Sept 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Signalen as a Service</Heading>
+            <p>Elaboration of the municipal requirements and wishes for management and support on 'Signalen-as-a-Service'.</p>
+            <ResponsiveImage src={saas} />
+          </Timeline.Content>
+        </Timeline.Container>
+
+        <Timeline.Container align="right">
+          <Timeline.Content>
+            <Span fontSize="0.9rem">Aug 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">First community day</Heading>
+            <p>First Signalen Community day with the core group. The municipalities of The Hague, Utrecht and Haarlem are also present as Signalen supporters.</p>
+            <ResponsiveImage src={community} />
+          </Timeline.Content>
+        </Timeline.Container>
+
         <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">April 2020</Span>
@@ -75,44 +103,35 @@ const RoadmapPage = ({ location }) => (
             <ResponsiveImage src={sprint} />
           </Timeline.Content>
         </Timeline.Container>
+
         <Timeline.Container align="right">
           <Timeline.Content>
-            <Span fontSize="0.9rem">Aug 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">First community day</Heading>
-            <p>First Signalen Community day with the core group. The municipalities of The Hague, Utrecht and Haarlem are also present as Signalen supporters.</p>
-            <ResponsiveImage src={community} />
+            <Span fontSize="0.9rem">March 2nd, 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Signalen core group</Heading>
+            <p>'s-Hertogenbosch, Amsterdam, Almere, VNG Realization and the Foundation for Public Code together form the Kopgroep with the aim of making Signalen usable for other municipalities.</p>
+            <ResponsiveImage src={connectingTeams} />
           </Timeline.Content>
         </Timeline.Container>
+
         <Timeline.Container align="left">
           <Timeline.Content>
-            <Span fontSize="0.9rem">Sept 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Signalen as a Service</Heading>
-            <p>Elaboration of the municipal requirements and wishes for management and support on 'Signalen-as-a-Service'.</p>
-            <ResponsiveImage src={saas} />
+            <Span fontSize="0.9rem">2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Start initiative</Heading>
+            <p>Start of the Signalen initiative! Many municipalities in the Netherlands are interested in Signalen. Based on this enthusiasm, VNGr starts scaling up Signalen.</p>
+            <ResponsiveImage src={startInitiatief} />
           </Timeline.Content>
         </Timeline.Container>
+
         <Timeline.Container align="right">
-          <Timeline.Content>
-            <Span fontSize="0.9rem">Sept 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Integral roadmap</Heading>
-            <p>The start towards one integral functional roadmap. The roadmap shows where Signalen is going and contains features that are valuable for every municipality.</p>
-          </Timeline.Content>
-        </Timeline.Container>
-        <Timeline.Container align="left">
-          <Timeline.Content>
-            <Span fontSize="0.9rem">Q4 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Ready for production</Heading>
-            <p>Delivery of a municipal neutral version of the Signalen software. Signalen is ready for production for the municipal participants from the core group.</p>
-          </Timeline.Content>
-        </Timeline.Container>
-        <Timeline.Container align="right">
-          <Timeline.Content>
-            <Span fontSize="0.9rem">2021</Span>
-            <Heading as="h3" fontSize="1.5rem">Scaling up</Heading>
-            <p>Scaling up Signalen at Dutch municipalities.</p>
-            <ResponsiveImage src={doorontwikkeling} />
-          </Timeline.Content>
-        </Timeline.Container>
+            <Timeline.Content>
+              <Span fontSize="0.9rem">2018</Span>
+              <Heading as="h3" fontSize="1.5rem">Start of development of SIA</Heading>
+              <p>The Municipality of Amsterdam starts the development of Signalen in Amsterdam (SIA) with the Department of Services and the Datalab. SIA is open source and therefore freely usable for others.</p>
+              <ResponsiveImage src={startOntwikkeling} />
+            </Timeline.Content>
+          </Timeline.Container>
+
+
       </Timeline>
     </Container>
     <Footer location={location} />

--- a/src/pages/roadmap.en.js
+++ b/src/pages/roadmap.en.js
@@ -47,7 +47,7 @@ const RoadmapPage = ({ location }) => (
         <Timeline.Content>
           <Span fontSize="0.9rem">Juli 2021</Span>
           <Heading as="h3" fontSize="1.5rem">Roadmap 2nd half 2021</Heading>
-          <p>The roadmap of Signalen has been defined by the product steering group. The community is now looking how to finance these developments. Read more about the <a href="/en/news/2021-06-24-roadmap/">roadmap 2021</a></p>
+          <p>The roadmap of Signalen has been defined by the product steering group. The community is now looking how to finance these developments. Read more about the <a href="/en/news/2021-06-24-roadmap/">roadmap 2021</a>.</p>
         </Timeline.Content>
       </Timeline.Container>
 

--- a/src/pages/roadmap.en.js
+++ b/src/pages/roadmap.en.js
@@ -43,7 +43,15 @@ const RoadmapPage = ({ location }) => (
     <Container>
       <Timeline>
 
-        <Timeline.Container align="left">
+      <Timeline.Container align="left">
+        <Timeline.Content>
+          <Span fontSize="0.9rem">Juli 2021</Span>
+          <Heading as="h3" fontSize="1.5rem">Roadmap 2nd half 2021</Heading>
+          <p>The roadmap of Signalen has been defined by the product steering group. The community is now looking how to finance these developments. Read more about the <a href="/en/news/2021-06-24-roadmap/">roadmap 2021</a></p>
+        </Timeline.Content>
+      </Timeline.Container>
+
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">May 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen is used in production at the municipality of 's-Hertogenbosch</Heading>
@@ -51,7 +59,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">2021</Span>
             <Heading as="h3" fontSize="1.5rem">Scaling up</Heading>
@@ -60,7 +68,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">Q4 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Ready for production</Heading>
@@ -68,7 +76,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">Sept 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Integral roadmap</Heading>
@@ -76,7 +84,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">Sept 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen as a Service</Heading>
@@ -85,7 +93,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">Aug 2020</Span>
             <Heading as="h3" fontSize="1.5rem">First community day</Heading>
@@ -94,7 +102,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">April 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Core group starts</Heading>
@@ -104,7 +112,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">March 2nd, 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen core group</Heading>
@@ -113,7 +121,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">2020</Span>
             <Heading as="h3" fontSize="1.5rem">Start initiative</Heading>
@@ -122,7 +130,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
             <Timeline.Content>
               <Span fontSize="0.9rem">2018</Span>
               <Heading as="h3" fontSize="1.5rem">Start of development of SIA</Heading>

--- a/src/pages/roadmap.en.js
+++ b/src/pages/roadmap.en.js
@@ -55,7 +55,7 @@ const RoadmapPage = ({ location }) => (
           <Timeline.Content>
             <Span fontSize="0.9rem">March 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen is used in production at the municipality of 's-Hertogenbosch</Heading>
-            <p>Signalen was taken into production at the beginning of May in the municipality of 's-Hertogenbosch.</p>
+            <p>Signalen was taken into production at the beginning of March in the municipality of 's-Hertogenbosch.</p>
           </Timeline.Content>
         </Timeline.Container>
 

--- a/src/pages/roadmap.en.js
+++ b/src/pages/roadmap.en.js
@@ -53,7 +53,7 @@ const RoadmapPage = ({ location }) => (
 
         <Timeline.Container align="right">
           <Timeline.Content>
-            <Span fontSize="0.9rem">May 2021</Span>
+            <Span fontSize="0.9rem">March 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen is used in production at the municipality of 's-Hertogenbosch</Heading>
             <p>Signalen was taken into production at the beginning of May in the municipality of 's-Hertogenbosch.</p>
           </Timeline.Content>

--- a/src/pages/roadmap.js
+++ b/src/pages/roadmap.js
@@ -55,7 +55,7 @@ const RoadmapPage = ({ location }) => (
           <Timeline.Content>
             <Span fontSize="0.9rem">Mei 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen in 's-Hertogenbosch</Heading>
-            <p>Signalen is begin mei in product genomen in de gemeente 's-Hertogenbosch.</p>
+            <p>Signalen is begin maart in product genomen in de gemeente 's-Hertogenbosch.</p>
           </Timeline.Content>
         </Timeline.Container>
 

--- a/src/pages/roadmap.js
+++ b/src/pages/roadmap.js
@@ -47,7 +47,7 @@ const RoadmapPage = ({ location }) => (
         <Timeline.Content>
           <Span fontSize="0.9rem">Juli 2021</Span>
           <Heading as="h3" fontSize="1.5rem">Roadmap 2e helft 2021 van Signalen</Heading>
-          <p>De roadmap van Signalen is vastgesteld door de product steering groep. Er wordt nu binnen community gekeken naar budget om deze ontwikkelingen te financieren. Lees hier meer over <a href="/news/2021-06-24-roadmap/">de roadmap 2021</a></p>
+          <p>De roadmap van Signalen is vastgesteld door de product steering groep. Er wordt nu binnen community gekeken naar budget om deze ontwikkelingen te financieren. Lees hier meer over <a href="/news/2021-06-24-roadmap/">de roadmap 2021</a>.</p>
         </Timeline.Content>
       </Timeline.Container>
 

--- a/src/pages/roadmap.js
+++ b/src/pages/roadmap.js
@@ -53,7 +53,7 @@ const RoadmapPage = ({ location }) => (
 
         <Timeline.Container align="right">
           <Timeline.Content>
-            <Span fontSize="0.9rem">Mei 2021</Span>
+            <Span fontSize="0.9rem">Maart 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen in 's-Hertogenbosch</Heading>
             <p>Signalen is begin maart in product genomen in de gemeente 's-Hertogenbosch.</p>
           </Timeline.Content>

--- a/src/pages/roadmap.js
+++ b/src/pages/roadmap.js
@@ -43,7 +43,7 @@ const RoadmapPage = ({ location }) => (
     <Container>
       <Timeline>
 
-      <Timeline.Container align="right">
+      <Timeline.Container align="left">
         <Timeline.Content>
           <Span fontSize="0.9rem">Juli 2021</Span>
           <Heading as="h3" fontSize="1.5rem">Roadmap 2e helft 2021 van Signalen</Heading>
@@ -51,7 +51,7 @@ const RoadmapPage = ({ location }) => (
         </Timeline.Content>
       </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">Mei 2021</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen in 's-Hertogenbosch</Heading>
@@ -60,7 +60,7 @@ const RoadmapPage = ({ location }) => (
         </Timeline.Container>
 
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">2021</Span>
             <Heading as="h3" fontSize="1.5rem">Opschalen</Heading>
@@ -69,7 +69,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">Q4 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Klaar voor productie</Heading>
@@ -77,7 +77,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">Sept 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Integrale roadmap </Heading>
@@ -85,7 +85,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">Sept 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Signalen as a Service</Heading>
@@ -94,7 +94,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">Aug 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Eerste communitydag</Heading>
@@ -103,7 +103,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">April 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Kopgroep van start</Heading>
@@ -113,7 +113,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">2 maart 2020</Span>
             <Heading as="h3" fontSize="1.5rem">Kopgroep Signalen</Heading>
@@ -122,7 +122,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="left">
+        <Timeline.Container align="right">
           <Timeline.Content>
             <Span fontSize="0.9rem">2020</Span>
             <Heading as="h3" fontSize="1.5rem">Start initiatief</Heading>
@@ -131,7 +131,7 @@ const RoadmapPage = ({ location }) => (
           </Timeline.Content>
         </Timeline.Container>
 
-        <Timeline.Container align="right">
+        <Timeline.Container align="left">
             <Timeline.Content>
               <Span fontSize="0.9rem">2018</Span>
               <Heading as="h3" fontSize="1.5rem">Start ontwikkeling SIA</Heading>

--- a/src/pages/roadmap.js
+++ b/src/pages/roadmap.js
@@ -42,30 +42,67 @@ const RoadmapPage = ({ location }) => (
     </Container>
     <Container>
       <Timeline>
+
       <Timeline.Container align="right">
-          <Timeline.Content>
-            <Span fontSize="0.9rem">2018</Span>
-            <Heading as="h3" fontSize="1.5rem">Start ontwikkeling SIA</Heading>
-            <p>Gemeente Amsterdam start de ontwikkeling van Signalen in Amsterdam (SIA) met de afdeling Dienstverlening en het Datalab. SIA is opensource en daarmee vrij bruikbaar voor anderen.</p>
-            <ResponsiveImage src={startOntwikkeling} />
-          </Timeline.Content>
-        </Timeline.Container>
+        <Timeline.Content>
+          <Span fontSize="0.9rem">Juli 2021</Span>
+          <Heading as="h3" fontSize="1.5rem">Roadmap 2e helft 2021 van Signalen</Heading>
+          <p>De roadmap van Signalen is vastgesteld door de product steering groep. Er wordt nu binnen community gekeken naar budget om deze ontwikkelingen te financieren. Lees hier meer over <a href="/news/2021-06-24-roadmap/">de roadmap 2021</a></p>
+        </Timeline.Content>
+      </Timeline.Container>
+
         <Timeline.Container align="left">
           <Timeline.Content>
-            <Span fontSize="0.9rem">2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Start initiatief</Heading>
-            <p>Start van het Signalen initiatief! Veel gemeenten in Nederland hebben interesse voor Signalen. Op basis van deze animo, start VNGr met het opschalen van Signalen.</p>
-            <ResponsiveImage src={startInitiatief} />
+            <Span fontSize="0.9rem">Mei 2021</Span>
+            <Heading as="h3" fontSize="1.5rem">Signalen in 's-Hertogenbosch</Heading>
+            <p>Signalen is begin mei in product genomen in de gemeente 's-Hertogenbosch.</p>
           </Timeline.Content>
         </Timeline.Container>
+
+
         <Timeline.Container align="right">
           <Timeline.Content>
-            <Span fontSize="0.9rem">2 maart 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Kopgroep Signalen</Heading>
-            <p>‘s-Hertogenbosch, Amsterdam, Almere, VNG Realisatie vormen samen de Kopgroep, gefaciliteerd door de Foundation for Public Code met als doel om Signalen bruikbaar te maken voor andere gemeenten.</p>
-            <ResponsiveImage src={connectingTeams} />
+            <Span fontSize="0.9rem">2021</Span>
+            <Heading as="h3" fontSize="1.5rem">Opschalen</Heading>
+            <p>Opschalen van Signalen bij Nederlandse gemeenten.</p>
+            <ResponsiveImage src={doorontwikkeling} />
           </Timeline.Content>
         </Timeline.Container>
+
+        <Timeline.Container align="left">
+          <Timeline.Content>
+            <Span fontSize="0.9rem">Q4 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Klaar voor productie</Heading>
+            <p>Oplevering gemeente-neutrale versie Signalen-software. Signalen is klaar voor productie bij de gemeentelijke deelnemers uit de Kopgroep.</p>
+          </Timeline.Content>
+        </Timeline.Container>
+
+        <Timeline.Container align="right">
+          <Timeline.Content>
+            <Span fontSize="0.9rem">Sept 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Integrale roadmap </Heading>
+            <p>De start richting één integrale functionele roadmap. De roadmap laat zien waar Signalen heen gaat en bevat features die voor iedere gemeente waardevol zijn.</p>
+          </Timeline.Content>
+        </Timeline.Container>
+
+        <Timeline.Container align="left">
+          <Timeline.Content>
+            <Span fontSize="0.9rem">Sept 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Signalen as a Service</Heading>
+            <p>Uitwerken van de gemeentelijke eisen en wensen v.w.b. Beheer en ondersteuning op ‘Signalen-as-a-Service’.</p>
+            <ResponsiveImage src={saas} />
+          </Timeline.Content>
+        </Timeline.Container>
+
+        <Timeline.Container align="right">
+          <Timeline.Content>
+            <Span fontSize="0.9rem">Aug 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Eerste communitydag</Heading>
+            <p>Eerste Signalen Communitydag met de Kopgroep. Ook de gemeenten Den Haag, Utrecht en Haarlem zijn aanwezig als Signalen supporters.</p>
+            <ResponsiveImage src={community} />
+          </Timeline.Content>
+        </Timeline.Container>
+
         <Timeline.Container align="left">
           <Timeline.Content>
             <Span fontSize="0.9rem">April 2020</Span>
@@ -75,44 +112,34 @@ const RoadmapPage = ({ location }) => (
             <ResponsiveImage src={sprint} />
           </Timeline.Content>
         </Timeline.Container>
+
         <Timeline.Container align="right">
           <Timeline.Content>
-            <Span fontSize="0.9rem">Aug 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Eerste communitydag</Heading>
-            <p>Eerste Signalen Communitydag met de Kopgroep. Ook de gemeenten Den Haag, Utrecht en Haarlem zijn aanwezig als Signalen supporters.</p>
-            <ResponsiveImage src={community} />
+            <Span fontSize="0.9rem">2 maart 2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Kopgroep Signalen</Heading>
+            <p>‘s-Hertogenbosch, Amsterdam, Almere, VNG Realisatie vormen samen de Kopgroep, gefaciliteerd door de Foundation for Public Code met als doel om Signalen bruikbaar te maken voor andere gemeenten.</p>
+            <ResponsiveImage src={connectingTeams} />
           </Timeline.Content>
         </Timeline.Container>
+
         <Timeline.Container align="left">
           <Timeline.Content>
-            <Span fontSize="0.9rem">Sept 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Signalen as a Service</Heading>
-            <p>Uitwerken van de gemeentelijke eisen en wensen v.w.b. Beheer en ondersteuning op ‘Signalen-as-a-Service’.</p>
-            <ResponsiveImage src={saas} />
+            <Span fontSize="0.9rem">2020</Span>
+            <Heading as="h3" fontSize="1.5rem">Start initiatief</Heading>
+            <p>Start van het Signalen initiatief! Veel gemeenten in Nederland hebben interesse voor Signalen. Op basis van deze animo, start VNGr met het opschalen van Signalen.</p>
+            <ResponsiveImage src={startInitiatief} />
           </Timeline.Content>
         </Timeline.Container>
+
         <Timeline.Container align="right">
-          <Timeline.Content>
-            <Span fontSize="0.9rem">Sept 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Integrale roadmap </Heading>
-            <p>De start richting één integrale functionele roadmap. De roadmap laat zien waar Signalen heen gaat en bevat features die voor iedere gemeente waardevol zijn.</p>
-          </Timeline.Content>
-        </Timeline.Container>
-        <Timeline.Container align="left">
-          <Timeline.Content>
-            <Span fontSize="0.9rem">Q4 2020</Span>
-            <Heading as="h3" fontSize="1.5rem">Klaar voor productie</Heading>
-            <p>Oplevering gemeente-neutrale versie Signalen-software. Signalen is klaar voor productie bij de gemeentelijke deelnemers uit de Kopgroep.</p>
-          </Timeline.Content>
-        </Timeline.Container>
-        <Timeline.Container align="right">
-          <Timeline.Content>
-            <Span fontSize="0.9rem">2021</Span>
-            <Heading as="h3" fontSize="1.5rem">Opschalen</Heading>
-            <p>Opschalen van Signalen bij Nederlandse gemeenten.</p>
-            <ResponsiveImage src={doorontwikkeling} />
-          </Timeline.Content>
-        </Timeline.Container>
+            <Timeline.Content>
+              <Span fontSize="0.9rem">2018</Span>
+              <Heading as="h3" fontSize="1.5rem">Start ontwikkeling SIA</Heading>
+              <p>Gemeente Amsterdam start de ontwikkeling van Signalen in Amsterdam (SIA) met de afdeling Dienstverlening en het Datalab. SIA is opensource en daarmee vrij bruikbaar voor anderen.</p>
+              <ResponsiveImage src={startOntwikkeling} />
+            </Timeline.Content>
+          </Timeline.Container>
+
       </Timeline>
     </Container>
     <Footer />


### PR DESCRIPTION
Implements #103 

- Add order on roadmap timeline. Latest developments on top, oldest below (NL/EN)
- Add roadmap news article (NL/EN)
- Updated roadmap highlight on main page
