### PR TITLE
Add security policy to the repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Signalen security policies
+
+Signalen development team is strongly committed to responsible reporting and disclosure of security-related issues. As such, we’ve adopted and follow a set of policies which conform to that ideal and are geared toward allowing us to deliver timely security updates to the official distribution of Signalen.
+
+## Reporting security issues
+
+**Short version: please report security issues by emailing signalen-security@lists.publiccode.net.**
+
+If you discover security issues in Signalen we request you to disclose these in a *responsible* way by e-mailing to signalen-security@lists.publiccode.net.
+
+It is extremely useful if you have a reproducible test case and/or clear steps on how to reproduce the vulnerability.
+
+Please do not report security issues on the public Github issue tracker, as this makes it visible which exploits exist before a fix is available, potentially comprising a lot of unprotected instances.
+
+Once you’ve submitted an issue via email, you should receive an acknowledgment from a member of the security team as soon as possible, and depending on the action to be taken, you may receive further followup emails.
+
+## Timeline of the process
+
+Signalen has a technical steering group, of which all members are involved in the handling of security issues.
+
+1. The recipients of the report first validate if there is indeed a (possible) issue.
+
+2. After validation, we confirm that we received the report and if it is indeed a valid issue.
+
+3. We have a private Github repository accessible to the technical steering group. In this repository, an issue is created for the vulnerability where the impact and possible solutions are discussed.
+
+4. The next step is to create a (draft) Github security advisory, which is only visible to the repository administrators and technical steering group. Severity and impact will be established here.
+
+5. If appropriate, we request a [CVE identifier](https://cve.mitre.org/cve/identifiers/) from Github.
+
+6. A patch is implemented, reviewed and tested in a private fork.
+
+7. During the patch development process, known service providers are contacted to inform them of the vulnerability and coordinate the release date and rollout of the fix.
+
+8. When the fix is tested and release coordination is done, the fix is merged into the primary repository. The security advisory and release are published. Service providers update their managed instances.
+
+9. The release and security vulnerability are communicated to the community. This includes a message to the mailing list and announcements on the Common Ground Slack.

--- a/src/pages/contact.en.md
+++ b/src/pages/contact.en.md
@@ -53,3 +53,7 @@ Every third Thursday of the month, 11:00–12:00 (CEST), contributing members of
 ### Code of Conduct
 
 We have a [code of conduct](https://github.com/Signalen/signalen.org/blob/master/CODE_OF_CONDUCT.md) that we expect you to follow.
+
+### Security policy
+
+We have a [security policy](https://github.com/Signalen/signalen.org/blob/master/SECURITY.md) for reporting security vulnerabilities.

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -51,4 +51,9 @@ Elke donderdag, 13:00–14:00 (CEST), houden ontwikkelaars van onze community ee
 Elke derde donderdag van de maand, 11:00–12:00 (CEST), houden product owners van onze community een productstuurvergadering om nieuwe functies of gebruikersproblemen te bespreken. U bent van harte welkom om deze bijeenkomst bij te wonen door een verzoek te sturen naar signalen-discuss@lists.publiccode.net. Zorg ervoor dat je eerst [lid wordt van de Signalen mailinglist] (https://lists.publiccode.net/mailman/postorius/lists/signalen-discuss.lists.publiccode.net/) voordat je een bericht verstuurt.
 
 ### Gedragscode
+
 We hebben een [gedragscode](https://github.com/Signalen/signalen.org/blob/master/CODE_OF_CONDUCT.md) waarvan we verwachten dat u deze volgt.
+
+### Beveiligingsbeleid
+
+Voor het melden van beveiligingsproblemen in de code vragen wij u om het [beveiligingsbeleid](https://github.com/Signalen/signalen.org/blob/master/SECURITY.md) te volgen.


### PR DESCRIPTION
We decided to close https://github.com/Amsterdam/signals/pull/713 and add the security policy here.

Closes https://github.com/Signalen/backend/issues/112